### PR TITLE
load .env.development if NODE_ENV is not set

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+APP_DEVELOPMENT=yes

--- a/src/__snapshots__/noenv.test.js.snap
+++ b/src/__snapshots__/noenv.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Defaults to development for NODE_ENV 1`] = `
 Object {
+  "APP_DEVELOPMENT": true,
   "APP_ROOT": Any<String>,
   "APP_SOURCE": Any<String>,
   "APP_TEST_OVERRIDE": "original",
@@ -12,6 +13,7 @@ Object {
 
 exports[`Defaults to development for NODE_ENV 2`] = `
 Object {
+  "APP_DEVELOPMENT": "true",
   "APP_ROOT": Any<String>,
   "APP_SOURCE": Any<String>,
   "APP_TEST_OVERRIDE": "\\"original\\"",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export function init(): void {
   // Cache Node environment at load time. We have to do it to make
   // sure that the serialization, which might happen later, is in sync
   // with the parsing of the conditional NODE_ENV files now.
-  const NODE_ENV = process.env.NODE_ENV
+  const NODE_ENV = process.env.NODE_ENV || "development"
 
   // Can be use for values like e.g. "client" or "server". Or `docker`. Or `staging`.
   const ENV_CONTEXT = process.env.ENV_CONTEXT


### PR DESCRIPTION
If no NODE_ENV is set, we assume it is development mode. In this case only .env and no .env.development is loaded.

My understanding is that having no NODE_ENV should lead to a default of NODE_ENV=DEVELOPMENT.