### PR TITLE
Expand after load all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1692,9 +1692,9 @@
       }
     },
     "@octokit/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-FGUUqZbIwl5UPvuUTWq8ly2B12gJGWjYh1DviBzZLXp5LzHUgyzL+NDGsXeE4vszXoGsD/JfpZS+kjkLiD2T9w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
+      "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
       "dev": true,
       "requires": {
         "@octokit/auth-token": "^2.4.0",
@@ -1702,55 +1702,46 @@
         "@octokit/request": "^5.4.0",
         "@octokit/types": "^5.0.0",
         "before-after-hook": "^2.1.0",
-        "universal-user-agent": "^5.0.0"
+        "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/endpoint": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.3.tgz",
-      "integrity": "sha512-Y900+r0gIz+cWp6ytnkibbD95ucEzDSKzlEnaWS52hbCDNcCJYO5mRmWW7HRAnDc7am+N/5Lnd8MppSaTYx1Yg==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.6.tgz",
+      "integrity": "sha512-7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==",
       "dev": true,
       "requires": {
         "@octokit/types": "^5.0.0",
-        "is-plain-object": "^3.0.0",
-        "universal-user-agent": "^5.0.0"
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
         "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
         }
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.1.tgz",
-      "integrity": "sha512-qgMsROG9K2KxDs12CO3bySJaYoUu2aic90qpFrv7A8sEBzZ7UFGvdgPKiLw5gOPYEYbS0Xf8Tvf84tJutHPulQ==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.6.tgz",
+      "integrity": "sha512-Rry+unqKTa3svswT2ZAuqenpLrzJd+JTv89LTeVa5UM/5OX8o4KTkPL7/1ABq4f/ZkELb0XEK/2IEoYwykcLXg==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^5.0.0",
-        "universal-user-agent": "^5.0.0"
+        "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.2.tgz",
-      "integrity": "sha512-3OO/SjB5BChRTVRRQcZzpL0ZGcDGEB2dBzNhfqVqqMs6WDwo7cYW8cDwxqW8+VvA78mDK/abXgR/UrYg4HqrQg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.4.0.tgz",
+      "integrity": "sha512-YT6Klz3LLH6/nNgi0pheJnUmTFW4kVnxGft+v8Itc41IIcjl7y1C8TatmKQBbCSuTSNFXO5pCENnqg6sjwpJhg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^5.0.0"
+        "@octokit/types": "^5.5.0"
       }
     },
     "@octokit/plugin-request-log": {
@@ -1760,86 +1751,66 @@
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.0.0.tgz",
-      "integrity": "sha512-emS6gysz4E9BNi9IrCl7Pm4kR+Az3MmVB0/DoDCmF4U48NbYG3weKyDlgkrz6Jbl4Mu4nDx8YWZwC4HjoTdcCA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.2.0.tgz",
+      "integrity": "sha512-1/qn1q1C1hGz6W/iEDm9DoyNoG/xdFDt78E3eZ5hHeUfJTLJgyAMdj9chL/cNBHjcjd+FH5aO1x0VCqR2RE0mw==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^5.0.0",
+        "@octokit/types": "^5.5.0",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.5.tgz",
-      "integrity": "sha512-atAs5GAGbZedvJXXdjtKljin+e2SltEs48B3naJjqWupYl2IUBbB/CJisyjbNHcKpHzb3E+OYEZ46G8eakXgQg==",
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
+      "integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
         "@octokit/types": "^5.0.0",
         "deprecation": "^2.0.0",
-        "is-plain-object": "^3.0.0",
-        "node-fetch": "^2.3.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "once": "^1.4.0",
-        "universal-user-agent": "^5.0.0"
+        "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
         "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
         }
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.1.tgz",
-      "integrity": "sha512-5lqBDJ9/TOehK82VvomQ6zFiZjPeSom8fLkFVLuYL3sKiIb5RB8iN/lenLkY7oBmyQcGP7FBMGiIZTO8jufaRQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^4.0.1",
+        "@octokit/types": "^5.0.1",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "4.1.10",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz",
-          "integrity": "sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==",
-          "dev": true,
-          "requires": {
-            "@types/node": ">= 8"
-          }
-        }
       }
     },
     "@octokit/rest": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.0.tgz",
-      "integrity": "sha512-4G/a42lry9NFGuuECnua1R1eoKkdBYJap97jYbWDNYBOUboWcM75GJ1VIcfvwDV/pW0lMPs7CEmhHoVrSV5shg==",
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.6.tgz",
+      "integrity": "sha512-ES4lZBKPJMX/yUoQjAZiyFjei9pJ4lTTfb9k7OtYoUzKPDLl/M8jiHqt6qeSauyU4eZGLw0sgP1WiQl9FYeM5w==",
       "dev": true,
       "requires": {
         "@octokit/core": "^3.0.0",
         "@octokit/plugin-paginate-rest": "^2.2.0",
         "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "4.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "4.2.0"
       }
     },
     "@octokit/types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.1.tgz",
-      "integrity": "sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+      "integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -2097,6 +2068,91 @@
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "26.0.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.14.tgz",
+      "integrity": "sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "diff-sequences": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@types/json-schema": {
@@ -3545,12 +3601,6 @@
         "tslib": "^1.10.0"
       }
     },
-    "changelog-filename-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/changelog-filename-regex/-/changelog-filename-regex-1.1.2.tgz",
-      "integrity": "sha512-kpOfKlZ9x2UpeC4at6FAXHLKfi/JEUqUqkPCb1JUCa5FnNbJIzOHRM9RfeQ1QDcpj+Gxuc/UoHqASgmEeFDejQ==",
-      "dev": true
-    },
     "char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -4199,13 +4249,13 @@
       "dev": true
     },
     "deprecated-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deprecated-obj/-/deprecated-obj-1.0.1.tgz",
-      "integrity": "sha512-igs766xNtF7Fv/R//gT644e6dr+bT6kJrg+qyJA9affCyvf70UUNKIUIMUSROBg1sPUrBnENPsDdDHcBLI5wFQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/deprecated-obj/-/deprecated-obj-2.0.0.tgz",
+      "integrity": "sha512-CkdywZC2rJ8RGh+y3MM1fw1EJ4oO/oNExGbRFv0AQoMS+faTd3nO7slYjkj/6t8OnIMUE+wxh6G97YHhK1ytrw==",
       "dev": true,
       "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.11"
+        "flat": "^5.0.2",
+        "lodash": "^4.17.20"
       }
     },
     "deprecation": {
@@ -4219,18 +4269,6 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
-    },
-    "detect-repo-changelog": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/detect-repo-changelog/-/detect-repo-changelog-1.0.1.tgz",
-      "integrity": "sha1-whCMu/CWTae8B0ZFtq0dO4CmvW0=",
-      "dev": true,
-      "requires": {
-        "changelog-filename-regex": "^1.1.0",
-        "is-regular-file": "^1.0.1",
-        "lodash.find": "^4.6.0",
-        "pify": "^2.3.0"
-      }
     },
     "diff-sequences": {
       "version": "26.0.0",
@@ -4362,11 +4400,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-    },
-    "dotenv-expand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -5575,21 +5608,10 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "~2.0.3"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        }
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
     },
     "flat-cache": {
       "version": "2.0.1",
@@ -5818,9 +5840,9 @@
       }
     },
     "git-up": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
-      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.2.tgz",
+      "integrity": "sha512-kbuvus1dWQB2sSW4cbfTeGpCMd8ge9jx9RKnhXhuJ7tnvT+NIrTVfYZxjtflZddQYcmdOTlkAcjmx7bor+15AQ==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -5828,9 +5850,9 @@
       }
     },
     "git-url-parse": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
-      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.2.0.tgz",
+      "integrity": "sha512-KPoHZg8v+plarZvto4ruIzzJLFQoRx+sUs5DQSr07By9IBKguVd+e6jwrFR6/TP6xrCJlNV1tPqLO1aREc7O2g==",
       "dev": true,
       "requires": {
         "git-up": "^4.0.0"
@@ -6171,12 +6193,12 @@
       }
     },
     "http2-wrapper": {
-      "version": "1.0.0-beta.4.6",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.4.6.tgz",
-      "integrity": "sha512-9oB4BiGDTI1FmIBlOF9OJ5hwJvcBEmPCqk/hy314Uhy2uq5TjekUZM8w8SPLLlUEM+mxNhXdPAXfrJN2Zbb/GQ==",
+      "version": "1.0.0-beta.5.2",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
+      "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
       "dev": true,
       "requires": {
-        "quick-lru": "^5.0.0",
+        "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
       },
       "dependencies": {
@@ -6715,16 +6737,10 @@
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
-    "is-regular-file": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regular-file/-/is-regular-file-1.1.1.tgz",
-      "integrity": "sha512-+1U3MZrVwC4HM6VUKk3L5fiHtNd2d9kayzEJhmQ+B+uIBPE/p8Fy8QVdkx0HIr3o9J5TOKJY40eI5GfTfBqbdA==",
-      "dev": true
-    },
     "is-ssh": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
-      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
+      "integrity": "sha512-elEw0/0c2UscLrNG+OAorbP539E3rhliKPg+hDMWN9VwrDXfYK+4PBEykDPfxlYYtQvl84TascnQyobfQLHEhQ==",
       "dev": true,
       "requires": {
         "protocols": "^1.1.0"
@@ -7887,6 +7903,12 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -8180,21 +8202,15 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
-    },
-    "lodash.find": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
       "dev": true
     },
     "lodash.get": {
@@ -8331,9 +8347,9 @@
       "dev": true
     },
     "macos-release": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
+      "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
       "dev": true
     },
     "magic-string": {
@@ -8716,9 +8732,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-gyp": {
@@ -9180,13 +9196,13 @@
       "dev": true
     },
     "os-name": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
-      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-4.0.0.tgz",
+      "integrity": "sha512-caABzDdJMbtykt7GmSogEat3faTKQhmZf0BS5l/pZGmP0vPWQjXWqOhbLyK+b6j2/DQPmEvYdzLXJXXLJNVDNg==",
       "dev": true,
       "requires": {
         "macos-release": "^2.2.0",
-        "windows-release": "^3.1.0"
+        "windows-release": "^4.0.0"
       }
     },
     "os-tmpdir": {
@@ -9344,9 +9360,9 @@
       }
     },
     "parse-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
-      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.2.tgz",
+      "integrity": "sha512-HSqVz6iuXSiL8C1ku5Gl1Z5cwDd9Wo0q8CoffdAghP6bz8pJa1tcMC+m4N+z6VAS8QdksnIGq1TB6EgR4vPR6w==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -9354,9 +9370,9 @@
       }
     },
     "parse-url": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
-      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.2.tgz",
+      "integrity": "sha512-Czj+GIit4cdWtxo3ISZCvLiUjErSo0iI3wJ+q9Oi3QuMYTI6OZu+7cewMWZ+C1YAnKhYTk6/TLuhIgCypLthPA==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -9911,9 +9927,9 @@
       }
     },
     "protocols": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
+      "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
       "dev": true
     },
     "psl": {
@@ -10244,48 +10260,45 @@
       }
     },
     "release-it": {
-      "version": "13.6.3",
-      "resolved": "https://registry.npmjs.org/release-it/-/release-it-13.6.3.tgz",
-      "integrity": "sha512-Y/MruGGuOqI6cqrSXoOI40BuTz5i5BVq7k/3754S86dNbnAWIPWCkuHBNTK3u0aYk6qjfsJUdE1x8yrNFju34A==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/release-it/-/release-it-14.0.3.tgz",
+      "integrity": "sha512-C/gJJqr4csU6OkhMJZlXnbPR+xgPlp2aO2BWJl5MIj8UPTavSYImwUkAXF2qZUknBE7ArfKVXkY8qUNZ31IyCA==",
       "dev": true,
       "requires": {
         "@iarna/toml": "2.2.5",
-        "@octokit/rest": "18.0.0",
+        "@octokit/rest": "18.0.6",
         "async-retry": "1.3.1",
         "chalk": "4.1.0",
-        "cosmiconfig": "6.0.0",
+        "cosmiconfig": "7.0.0",
         "debug": "4.1.1",
-        "deprecated-obj": "1.0.1",
-        "detect-repo-changelog": "1.0.1",
-        "execa": "4.0.2",
-        "find-up": "4.1.0",
+        "deprecated-obj": "2.0.0",
+        "execa": "4.0.3",
+        "find-up": "5.0.0",
         "form-data": "3.0.0",
-        "git-url-parse": "11.1.2",
+        "git-url-parse": "11.2.0",
         "globby": "11.0.1",
-        "got": "11.3.0",
+        "got": "11.6.2",
         "import-cwd": "3.0.0",
-        "inquirer": "7.1.0",
+        "inquirer": "7.3.3",
         "is-ci": "2.0.0",
-        "lodash": "4.17.15",
+        "lodash": "4.17.20",
         "mime-types": "2.1.27",
-        "ora": "4.0.4",
-        "os-name": "3.1.0",
-        "parse-json": "5.0.0",
+        "ora": "5.1.0",
+        "os-name": "4.0.0",
+        "parse-json": "5.1.0",
         "semver": "7.3.2",
         "shelljs": "0.8.4",
-        "supports-color": "7.1.0",
-        "update-notifier": "4.1.0",
+        "update-notifier": "4.1.1",
         "url-join": "4.0.1",
-        "uuid": "8.1.0",
-        "window-size": "1.1.1",
+        "uuid": "8.3.0",
         "yaml": "1.10.0",
-        "yargs-parser": "18.1.3"
+        "yargs-parser": "20.0.0"
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
-          "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
+          "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
           "dev": true
         },
         "@szmarczak/http-timer": {
@@ -10322,6 +10335,31 @@
             "supports-color": "^7.1.0"
           }
         },
+        "cli-spinners": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
+          "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
+          "dev": true
+        },
+        "cli-width": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+          "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
         "decompress-response": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -10338,9 +10376,9 @@
           "dev": true
         },
         "execa": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
-          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -10352,6 +10390,16 @@
             "onetime": "^5.1.0",
             "signal-exit": "^3.0.2",
             "strip-final-newline": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "form-data": {
@@ -10366,29 +10414,28 @@
           }
         },
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "got": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.3.0.tgz",
-          "integrity": "sha512-yi/kiZY2tNMtt5IfbfX8UL3hAZWb2gZruxYZ72AY28pU5p0TZjZdl0uRsuaFbnC0JopdUi3I+Mh1F3dPQ9Dh0Q==",
+          "version": "11.6.2",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.6.2.tgz",
+          "integrity": "sha512-/21qgUePCeus29Jk7MEti8cgQUNXFSWfIevNIk4H7u1wmXNDrGPKPY6YsPY+o9CIT/a2DjCjRz0x1nM9FtS2/A==",
           "dev": true,
           "requires": {
-            "@sindresorhus/is": "^2.1.1",
+            "@sindresorhus/is": "^3.1.1",
             "@szmarczak/http-timer": "^4.0.5",
             "@types/cacheable-request": "^6.0.1",
             "@types/responselike": "^1.0.0",
             "cacheable-lookup": "^5.0.3",
             "cacheable-request": "^7.0.1",
             "decompress-response": "^6.0.0",
-            "get-stream": "^5.1.0",
-            "http2-wrapper": "^1.0.0-beta.4.5",
+            "http2-wrapper": "^1.0.0-beta.5.2",
             "lowercase-keys": "^2.0.0",
             "p-cancelable": "^2.0.0",
             "responselike": "^2.0.0"
@@ -10401,36 +10448,24 @@
           "dev": true
         },
         "inquirer": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-          "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+          "version": "7.3.3",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+          "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
-            "chalk": "^3.0.0",
+            "chalk": "^4.1.0",
             "cli-cursor": "^3.1.0",
-            "cli-width": "^2.0.0",
+            "cli-width": "^3.0.0",
             "external-editor": "^3.0.3",
             "figures": "^3.0.0",
-            "lodash": "^4.17.15",
+            "lodash": "^4.17.19",
             "mute-stream": "0.0.8",
             "run-async": "^2.4.0",
-            "rxjs": "^6.5.3",
+            "rxjs": "^6.6.0",
             "string-width": "^4.1.0",
             "strip-ansi": "^6.0.0",
             "through": "^2.3.6"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            }
           }
         },
         "is-stream": {
@@ -10446,12 +10481,21 @@
           "dev": true
         },
         "keyv": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
-          "integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+          "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
           "dev": true,
           "requires": {
             "json-buffer": "3.0.1"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
           }
         },
         "lowercase-keys": {
@@ -10475,23 +10519,63 @@
             "path-key": "^3.0.0"
           }
         },
+        "ora": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.1.0.tgz",
+          "integrity": "sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "cli-cursor": "^3.1.0",
+            "cli-spinners": "^2.4.0",
+            "is-interactive": "^1.0.0",
+            "log-symbols": "^4.0.0",
+            "mute-stream": "0.0.8",
+            "strip-ansi": "^6.0.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
         "p-cancelable": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
           "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
           "dev": true
         },
-        "parse-json": {
+        "p-limit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
         },
         "responselike": {
           "version": "2.0.0",
@@ -10502,6 +10586,15 @@
             "lowercase-keys": "^2.0.0"
           }
         },
+        "rxjs": {
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -10509,18 +10602,57 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
         },
+        "update-notifier": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.1.tgz",
+          "integrity": "sha512-9y+Kds0+LoLG6yN802wVXoIfxYEwh3FlZwzMwpCZp62S2i1/Jzeqb9Eeeju3NSHccGGasfGlK5/vEHbAifYRDg==",
+          "dev": true,
+          "requires": {
+            "boxen": "^4.2.0",
+            "chalk": "^3.0.0",
+            "configstore": "^5.0.1",
+            "has-yarn": "^2.1.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^2.0.0",
+            "is-installed-globally": "^0.3.1",
+            "is-npm": "^4.0.0",
+            "is-yarn-global": "^0.3.0",
+            "latest-version": "^5.0.0",
+            "pupa": "^2.0.1",
+            "semver-diff": "^3.1.1",
+            "xdg-basedir": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            }
+          }
+        },
         "uuid": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-          "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "20.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.0.0.tgz",
+          "integrity": "sha512-8eblPHTL7ZWRkyjIZJjnGf+TijiKJSwA24svzLRVvtgoi/RZiKa9fFQTrlx0OKLnyHSdt/enrdadji6WFfESVA==",
           "dev": true
         }
       }
@@ -12328,13 +12460,10 @@
       }
     },
     "universal-user-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-      "dev": true,
-      "requires": {
-        "os-name": "^3.1.0"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
     },
     "universalify": {
       "version": "1.0.0",
@@ -12725,83 +12854,56 @@
         "string-width": "^4.0.0"
       }
     },
-    "window-size": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-1.1.1.tgz",
-      "integrity": "sha512-5D/9vujkmVQ7pSmc0SCBmHXbkv6eaHwXEx65MywhmUMsI8sGqJ972APq1lotfcwMKPFLuCFfL8xGHLIp7jaBmA==",
+    "windows-release": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-4.0.0.tgz",
+      "integrity": "sha512-OxmV4wzDKB1x7AZaZgXMVsdJ1qER1ed83ZrTYd5Bwq2HfJVg3DJS8nqlAG4sMoJ7mu8cuRmLEYyU13BKwctRAg==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "is-number": "^3.0.0"
+        "execa": "^4.0.2"
       },
       "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+        "execa": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
         },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "pump": "^3.0.0"
           }
         },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.0"
-          }
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
         },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
+            "path-key": "^3.0.0"
           }
         }
-      }
-    },
-    "windows-release": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
-      "integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@effective/eslint-config": "^3.7.1",
     "@effective/prettier": "^4.0.3",
     "@types/app-root-dir": "^0.1.0",
+    "@types/jest": "^26.0.14",
     "@types/yargs": "^15.0.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^26.0.1",
@@ -71,7 +72,7 @@
     "lint-staged": "^10.2.10",
     "preppy": "^10.5.0",
     "prettier": "^2.0.5",
-    "release-it": "^13.6.3",
+    "release-it": "^14.0.3",
     "rimraf": "^3.0.2",
     "typescript": "^3.9.5"
   },
@@ -81,7 +82,6 @@
     "core-js": "^3.6.5",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
-    "dotenv-expand": "^5.1.0",
     "yargs": "^15.3.1"
   },
   "husky": {

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,16 @@ Files are being loaded in this order. Values which are already set are never ove
 
 Note: `local` files without `NODE_ENV` are not respected when running in `NODE_ENV=test`.
 
+## Variable expansion
+
+Variable expansion is supported by _universal-dotenv_. All identifiers in environment values prefixed by `$` (dollar sign) or surrounded by `${NAME}` are expanded. Used algorithm is:
+
+- Merge all .env files and command line environment settings into one map (see File Priority)
+- Check every environment setting for variable expansion identifiers
+- Expand variable expansion identifiers recursively
+
+See files in `testcase/hierarchy` for an example of a complex variable expansion.
+
 ## Basic Usage
 
 All loading features are enabled by importing the core module itself and run init():

--- a/src/auto.test.js
+++ b/src/auto.test.js
@@ -1,5 +1,10 @@
 import { getEnvironment } from "."
 
+const savedProcessEnv = { ...process.env }
+afterAll(() => {
+  process.env = savedProcessEnv
+})
+
 test("init() is called on getEnvironment()", () => {
   const { raw } = getEnvironment()
   expect(raw.APP_TEST_PATH).toBe("one/two/three.js")

--- a/src/build.test.js
+++ b/src/build.test.js
@@ -6,6 +6,11 @@ const snapshotOpts = {
   APP_SOURCE: expect.any(String)
 }
 
+const savedProcessEnv = { ...process.env }
+afterAll(() => {
+  process.env = savedProcessEnv
+})
+
 /* eslint-disable import/no-commonjs */
 // We can't use ESM when relying on the fact the the env from the top is correctly respected.
 const api = require("..")

--- a/src/envExpand.test.ts
+++ b/src/envExpand.test.ts
@@ -1,0 +1,135 @@
+/* eslint-disable no-template-curly-in-string */
+import { expandEnvironment, expandSingleValue } from "./envExpand"
+
+describe("expand variable", () => {
+  test("with curly brackets", () => {
+    const result = expandSingleValue("test ${EXPAND} value", {
+      EXPAND: "expanded"
+    })
+
+    expect(result).toMatchInlineSnapshot(`"test expanded value"`)
+  })
+
+  test("simple", () => {
+    const result = expandSingleValue("test $EXPAND value", {
+      EXPAND: "expanded"
+    })
+
+    expect(result).toMatchInlineSnapshot(`"test expanded value"`)
+  })
+})
+
+test("expand undefined variable to empty string", () => {
+  const result = expandSingleValue("test $UNDEFINED_KEY value", {})
+
+  expect(result).toMatchInlineSnapshot(`"test  value"`)
+})
+
+describe("expand variable recursive", () => {
+  test("with curly brackets", () => {
+    const result = expandSingleValue("test ${EXPAND2} value", {
+      EXPAND: "expanded",
+      EXPAND2: "- ${EXPAND} -"
+    })
+
+    expect(result).toMatchInlineSnapshot(`"test - expanded - value"`)
+  })
+
+  test("simple", () => {
+    const result = expandSingleValue("test $EXPAND2 value", {
+      EXPAND: "expanded",
+      EXPAND2: "- $EXPAND -"
+    })
+
+    expect(result).toMatchInlineSnapshot(`"test - expanded - value"`)
+  })
+
+  test("multi layer recursive expansion", () => {
+    const result = expandSingleValue(
+      "scheme://${DOMAIN}/${PATH}",
+      {
+        DOMAIN: "${SECRET}@example.com",
+        SECRET: "${USERNAME}:${PASSWORD}",
+        USERNAME: "testuser",
+        PATH: "api/test",
+        PASSWORD: "not in .env file!"
+      },
+      {
+        PASSWORD: "a1s2d3f4g5"
+      }
+    )
+
+    expect(result).toMatchInlineSnapshot(
+      `"scheme://testuser:a1s2d3f4g5@example.com/api/test"`
+    )
+  })
+})
+
+test("kind of expand string in expand string", () => {
+  const result = expandSingleValue("test ${${EXPAND}} value", {
+    EXPAND: "expanded"
+  })
+
+  expect(result).toMatchInlineSnapshot(`"test \${expanded} value"`)
+})
+
+test("expand process environment settings", () => {
+  const result = expandSingleValue(
+    "test ${EXPAND} value",
+    {},
+    {
+      EXPAND: "expanded"
+    }
+  )
+
+  expect(result).toMatchInlineSnapshot(`"test expanded value"`)
+})
+
+test("prefer process environment settings", () => {
+  const result = expandSingleValue(
+    "test ${EXPAND} value",
+    {
+      EXPAND: "wrong expanded"
+    },
+    {
+      EXPAND: "expanded"
+    }
+  )
+
+  expect(result).toMatchInlineSnapshot(`"test expanded value"`)
+})
+
+test("no expansion of inline escaped dollar sign", () => {
+  const result = expandSingleValue("test \\${EXPAND} value", {
+    EXPAND: "expanded"
+  })
+
+  expect(result).toMatchInlineSnapshot(`"test \${EXPAND} value"`)
+})
+
+test("mixed inline escaped and normal expansion variables", () => {
+  const result = expandSingleValue("test \\${EXPAND} - $EXPAND value", {
+    EXPAND: "expanded"
+  })
+
+  expect(result).toMatchInlineSnapshot(`"test \${EXPAND} - expanded value"`)
+})
+
+test("expand environment map", () => {
+  const result = expandEnvironment(
+    {
+      ENV1: "env1",
+      ENV2: "expand env2 with env3: ${ENV3}",
+      ENV3: "env3"
+    },
+    {}
+  )
+
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "ENV1": "env1",
+      "ENV2": "expand env2 with env3: env3",
+      "ENV3": "env3",
+    }
+  `)
+})

--- a/src/envExpand.ts
+++ b/src/envExpand.ts
@@ -1,0 +1,71 @@
+/* eslint-disable unicorn/no-unsafe-regex */
+// It should be fine to have unsafe regex (with maybe exponential time) here as this is
+// only triggered once on start and is defined by admin or devops
+
+export type EnvironmentVariables = Record<string, string>
+
+/**
+ * Expand environment variables
+ * Based upon https://github.com/motdotla/dotenv-expand
+ * but does not change process.env itself
+ */
+export function expandSingleValue(
+  envValue: string,
+  environment: EnvironmentVariables,
+  processEnvironment?: NodeJS.ProcessEnv
+): string {
+  const matches = envValue.match(/(.?\${?(?:\w+)?}?)/g) || []
+
+  return matches.reduce((prev, match) => {
+    const matchParts = /(.?)\${?(\w+)?}?/g.exec(match)
+    const prefix = matchParts[1]
+    const key = matchParts[2]
+
+    if (key === undefined) {
+      // Looks like a matcher but has no key, so no change
+      return prev
+    }
+
+    let value: string
+    let replacePart: string
+
+    if (prefix === "\\") {
+      // Dollar sign is prefixed so no expansion
+      replacePart = matchParts[0]
+      value = replacePart.replace("\\$", "$")
+    } else {
+      // Found expansion matcher, so expand
+      replacePart = matchParts[0].slice(prefix.length)
+
+      // processEnvironment wins over environment
+      value = processEnvironment?.[key] ?? environment[key] ?? ""
+
+      // Resolve recursive interpolations
+      value = expandSingleValue(value, environment, processEnvironment)
+    }
+
+    return prev.replace(replacePart, value)
+  }, envValue)
+}
+
+/**
+ * Expands environment map
+ *
+ * - ${VARNAME}
+ * - $VARNAME
+ *
+ * @param environment Environment map to expand
+ * @param processEnvironment usually process.env to let command line ENV win over .env files
+ */
+export function expandEnvironment(
+  environment: EnvironmentVariables,
+  processEnvironment: NodeJS.ProcessEnv = process.env
+): EnvironmentVariables {
+  return Object.entries(environment).reduce(
+    (prev, [envKey, envValue]) => ({
+      ...prev,
+      [envKey]: expandSingleValue(envValue, environment, processEnvironment)
+    }),
+    {} as EnvironmentVariables
+  )
+}

--- a/src/expand.test.ts
+++ b/src/expand.test.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import path from "path"
+
+import appRoot from "app-root-dir"
+
+import { init } from "."
+
+const realAppRootDir = jest.requireActual<appRoot>("app-root-dir")
+jest.mock("app-root-dir")
+const appRootGet = appRoot.get as jest.Mock<string>
+
+const hierarchyRootDir = path.join(realAppRootDir.get(), "testcase", "hierarchy")
+
+const savedProcessEnv = { ...process.env }
+afterAll(() => {
+  process.env = savedProcessEnv
+})
+
+beforeEach(() => {
+  process.env = {}
+})
+
+test("expand variables", () => {
+  appRootGet.mockReturnValue(hierarchyRootDir)
+
+  init()
+
+  expect(process.env.ENV).toMatchInlineSnapshot(`".env"`)
+  expect(process.env.BASE).toMatchInlineSnapshot(
+    `"replace variable based on file '.env'"`
+  )
+})
+
+test("expand outer variable by inner variables", () => {
+  process.env.ENV_CONTEXT = "inner"
+  appRootGet.mockReturnValue(hierarchyRootDir)
+
+  init()
+
+  expect(process.env.ENV).toMatchInlineSnapshot(`".env.inner"`)
+  expect(process.env.BASE).toMatchInlineSnapshot(
+    `"replace variable based on file '.env.inner'"`
+  )
+})
+
+test("expand inner variable by outer variables", () => {
+  process.env.ENV_CONTEXT = "inner"
+  appRootGet.mockReturnValue(hierarchyRootDir)
+
+  init()
+
+  expect(process.env.DEEPREPLACER).toMatchInlineSnapshot(`"deep replacer"`)
+  expect(process.env.INNEREXPANDED).toMatchInlineSnapshot(
+    `"this is expanded by outer var: deep replacer"`
+  )
+})
+
+test("expand inner variable by local variables", () => {
+  process.env.ENV_CONTEXT = "inner"
+  appRootGet.mockReturnValue(hierarchyRootDir)
+
+  init()
+
+  expect(process.env.LOCALREPLACER).toMatchInlineSnapshot(`"local replacer"`)
+  expect(process.env.LOCALREPLACED).toMatchInlineSnapshot(
+    `"this is expanded by .local file: local replacer"`
+  )
+})

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,10 @@
 import { getEnvironment, init } from "."
 
+const savedProcessEnv = { ...process.env }
+afterAll(() => {
+  process.env = savedProcessEnv
+})
+
 init()
 
 const snapshotOpts = {

--- a/src/noenv.test.js
+++ b/src/noenv.test.js
@@ -1,3 +1,8 @@
+const savedProcessEnv = { ...process.env }
+afterAll(() => {
+  process.env = savedProcessEnv
+})
+
 /* eslint-disable global-require, @typescript-eslint/no-var-requires */
 // Clear pre-existing NODE_ENV variable
 delete process.env.NODE_ENV

--- a/testcase/hierarchy/.env
+++ b/testcase/hierarchy/.env
@@ -1,0 +1,3 @@
+BASE=replace variable based on file '${ENV}'
+ENV=.env
+DEEPREPLACER=deep replacer

--- a/testcase/hierarchy/.env.inner
+++ b/testcase/hierarchy/.env.inner
@@ -1,0 +1,3 @@
+ENV=.env.inner
+INNEREXPANDED=this is expanded by outer var: ${DEEPREPLACER}
+LOCALREPLACED=this is expanded by .local file: ${LOCALREPLACER}

--- a/testcase/hierarchy/.env.local
+++ b/testcase/hierarchy/.env.local
@@ -1,0 +1,1 @@
+LOCALREPLACER=local replacer


### PR DESCRIPTION
The current situation is that only variables of the same rank or deeper are expanded. This MR changes this behaviour so that first all environment variables (universal .env files and command line environment parameter) are merged into final environment map and then all variables are expanded.

**Why is this needed?**

We have a general URL setting expanded by an auth secret in _.env.APPNAME_ file:

`MY_SERVICE=https://${AUTH}@example.com/api/APPNAME/path`

We have a second parameter in _.env.SECONDAPPNAME_ file:

`MY_SERVICE=https://${AUTH}@example.com/api/SECONDAPPNAME/path`

_AUTH_ is set by secrets service in CI build. For local testing we have a `.env.local` file with

`AUTH=1234`

Having ENV_CONTEXT=APPNAME this results in an environment variable `MY_SERVICE=https://@example.com/api/APPNAME/path` as _AUTH_ is not in _.env.APPNAME_ or _.env.APPNAME.local_